### PR TITLE
refactor: remove unneeded double quotes

### DIFF
--- a/catppuccin.gitconfig
+++ b/catppuccin.gitconfig
@@ -1,127 +1,127 @@
 [delta "catppuccin-latte"]
 	blame-palette = "#eff1f5 #e6e9ef #dce0e8 #ccd0da #bcc0cc"
-	commit-decoration-style = "box ul"
+	commit-decoration-style = box ul
 	light = true
 	file-decoration-style = "#4c4f69"
 	file-style = "#4c4f69"
-	hunk-header-decoration-style = "box ul"
-	hunk-header-file-style = "bold"
-	hunk-header-line-number-style = "bold #6c6f85"
-	hunk-header-style = "file line-number syntax"
+	hunk-header-decoration-style = box ul
+	hunk-header-file-style = bold
+	hunk-header-line-number-style = bold "#6c6f85"
+	hunk-header-style = file line-number syntax
 	line-numbers = true
 	line-numbers-left-style = "#9ca0b0"
-	line-numbers-minus-style = "bold #d20f39"
-	line-numbers-plus-style = "bold #40a02b"
+	line-numbers-minus-style = bold "#d20f39"
+	line-numbers-plus-style = bold "#40a02b"
 	line-numbers-right-style = "#9ca0b0"
 	line-numbers-zero-style = "#9ca0b0"
 	# 25% red 75% base
-	minus-emph-style = "bold syntax #e8b9c6"
+	minus-emph-style = bold syntax "#e8b9c6"
 	# 10% red 90% base
-	minus-style = "syntax #ecdae2"
+	minus-style = syntax "#ecdae2"
 	# 25% green 75% base
-	plus-emph-style = "bold syntax #c3ddc3"
+	plus-emph-style = bold syntax "#c3ddc3"
 	# 10% green 90% base
-	plus-style = "syntax #dee8e0"
+	plus-style = syntax "#dee8e0"
 	map-styles = \
 		bold purple => syntax "#d5c3f4", \
 		bold blue => syntax "#bbcff5", \
 		bold cyan => syntax "#b4def1", \
 		bold yellow => syntax "#ebd9bf"
 	# Should match the name of the bat theme
-	syntax-theme = "Catppuccin Latte"
+	syntax-theme = Catppuccin Latte
 
 [delta "catppuccin-frappe"]
 	blame-palette = "#303446 #292c3c #232634 #414559 #51576d"
-	commit-decoration-style = "box ul"
+	commit-decoration-style = box ul
 	dark = true
 	file-decoration-style = "#c6d0f5"
 	file-style = "#c6d0f5"
-	hunk-header-decoration-style = "box ul"
-	hunk-header-file-style = "bold"
-	hunk-header-line-number-style = "bold #a5adce"
-	hunk-header-style = "file line-number syntax"
+	hunk-header-decoration-style = box ul
+	hunk-header-file-style = bold
+	hunk-header-line-number-style = bold "#a5adce"
+	hunk-header-style = file line-number syntax
 	line-numbers = true
 	line-numbers-left-style = "#737994"
-	line-numbers-minus-style = "bold #e78284"
-	line-numbers-plus-style = "bold #a6d189"
+	line-numbers-minus-style = bold "#e78284"
+	line-numbers-plus-style = bold "#a6d189"
 	line-numbers-right-style = "#737994"
 	line-numbers-zero-style = "#737994"
 	# 25% red 75% base
-	minus-emph-style = "bold syntax #5e4855"
+	minus-emph-style = bold syntax "#5e4855"
 	# 10% red 90% base
-	minus-style = "syntax #433c4c"
+	minus-style = syntax "#433c4c"
 	# 25% green 75% base
-	plus-emph-style = "bold syntax #4e5b56"
+	plus-emph-style = bold syntax "#4e5b56"
 	# 10% green 90% base
-	plus-style = "syntax #3c444d"
+	plus-style = syntax "#3c444d"
 	map-styles = \
 		bold purple => syntax "#574f6e", \
 		bold blue => syntax "#475270", \
 		bold cyan => syntax "#4a5b6b", \
 		bold yellow => syntax "#5d5958"
 	# Should match the name of the bat theme
-	syntax-theme = "Catppuccin Frappe"
+	syntax-theme = Catppuccin Frappe
 
 [delta "catppuccin-macchiato"]
 	blame-palette = "#24273a #1e2030 #181926 #363a4f #494d64"
-	commit-decoration-style = "box ul"
+	commit-decoration-style = box ul
 	dark = true
 	file-decoration-style = "#cad3f5"
 	file-style = "#cad3f5"
-	hunk-header-decoration-style = "box ul"
-	hunk-header-file-style = "bold"
-	hunk-header-line-number-style = "bold #a5adcb"
-	hunk-header-style = "file line-number syntax"
+	hunk-header-decoration-style = box ul
+	hunk-header-file-style = bold
+	hunk-header-line-number-style = bold "#a5adcb"
+	hunk-header-style = file line-number syntax
 	line-numbers = true
 	line-numbers-left-style = "#6e738d"
-	line-numbers-minus-style = "bold #ed8796"
-	line-numbers-plus-style = "bold #a6da95"
+	line-numbers-minus-style = bold "#ed8796"
+	line-numbers-plus-style = bold "#a6da95"
 	line-numbers-right-style = "#6e738d"
 	line-numbers-zero-style = "#6e738d"
 	# 25% red 75% base
-	minus-emph-style = "bold syntax #563f51"
+	minus-emph-style = bold syntax "#563f51"
 	# 10% red 90% base
-	minus-style = "syntax #383143"
+	minus-style = syntax "#383143"
 	# 25% green 75% base
-	plus-emph-style = "bold syntax #455450"
+	plus-emph-style = bold syntax "#455450"
 	# 10% green 90% base
-	plus-style = "syntax #313943"
+	plus-style = syntax "#313943"
 	map-styles = \
 		bold purple => syntax "#4d4569", \
 		bold blue => syntax "#3e4868", \
 		bold cyan => syntax "#3f5364", \
 		bold yellow => syntax "#575253"
 	# Should match the name of the bat theme
-	syntax-theme = "Catppuccin Macchiato"
+	syntax-theme = Catppuccin Macchiato
 
 [delta "catppuccin-mocha"]
 	blame-palette = "#1e1e2e #181825 #11111b #313244 #45475a"
-	commit-decoration-style = "box ul"
+	commit-decoration-style = box ul
 	dark = true
 	file-decoration-style = "#cdd6f4"
 	file-style = "#cdd6f4"
-	hunk-header-decoration-style = "box ul"
-	hunk-header-file-style = "bold"
-	hunk-header-line-number-style = "bold #a6adc8"
-	hunk-header-style = "file line-number syntax"
+	hunk-header-decoration-style = box ul
+	hunk-header-file-style = bold
+	hunk-header-line-number-style = bold "#a6adc8"
+	hunk-header-style = file line-number syntax
 	line-numbers = true
 	line-numbers-left-style = "#6c7086"
-	line-numbers-minus-style = "bold #f38ba8"
-	line-numbers-plus-style = "bold #a6e3a1"
+	line-numbers-minus-style = bold "#f38ba8"
+	line-numbers-plus-style = bold "#a6e3a1"
 	line-numbers-right-style = "#6c7086"
 	line-numbers-zero-style = "#6c7086"
 	# 25% red 75% base
-	minus-emph-style = "bold syntax #53394c"
+	minus-emph-style = bold syntax "#53394c"
 	# 10% red 90% base
-	minus-style = "syntax #34293a"
+	minus-style = syntax "#34293a"
 	# 25% green 75% base
-	plus-emph-style = "bold syntax #404f4a"
+	plus-emph-style = bold syntax "#404f4a"
 	# 10% green 90% base
-	plus-style = "syntax #2c3239"
+	plus-style = syntax "#2c3239"
 	map-styles = \
 		bold purple => syntax "#494060", \
 		bold blue => syntax "#384361", \
 		bold cyan => syntax "#384d5d", \
 		bold yellow => syntax "#544f4e"
 	# Should match the name of the bat theme
-	syntax-theme = "Catppuccin Mocha"
+	syntax-theme = Catppuccin Mocha

--- a/delta.tera
+++ b/delta.tera
@@ -10,35 +10,35 @@ whiskers:
 
 [delta "catppuccin-{{ identifier }}"]
 	blame-palette = "{{ palette.base.hex }} {{ palette.mantle.hex }} {{ palette.crust.hex }} {{ palette.surface0.hex }} {{ palette.surface1.hex }}"
-	commit-decoration-style = "box ul"
+	commit-decoration-style = box ul
 	{{ if(cond=flavor.dark, t="dark", f="light") }} = true
 	file-decoration-style = "{{ palette.text.hex }}"
 	file-style = "{{ palette.text.hex }}"
-	hunk-header-decoration-style = "box ul"
-	hunk-header-file-style = "bold"
-	hunk-header-line-number-style = "bold {{ palette.subtext0.hex }}"
-	hunk-header-style = "file line-number syntax"
+	hunk-header-decoration-style = box ul
+	hunk-header-file-style = bold
+	hunk-header-line-number-style = bold "{{ palette.subtext0.hex }}"
+	hunk-header-style = file line-number syntax
 	line-numbers = true
 	line-numbers-left-style = "{{ palette.overlay0.hex }}"
-	line-numbers-minus-style = "bold {{ palette.red.hex }}"
-	line-numbers-plus-style = "bold {{ palette.green.hex }}"
+	line-numbers-minus-style = bold "{{ palette.red.hex }}"
+	line-numbers-plus-style = bold "{{ palette.green.hex }}"
 	line-numbers-right-style = "{{ palette.overlay0.hex }}"
 	line-numbers-zero-style = "{{ palette.overlay0.hex }}"
 	# 25% red 75% base
-	minus-emph-style = "bold syntax {{ palette.red | mix(color=palette.base, amount=0.25) | get(key="hex") }}"
+	minus-emph-style = bold syntax "{{ palette.red | mix(color=palette.base, amount=0.25) | get(key="hex") }}"
 	# 10% red 90% base
-	minus-style = "syntax {{ palette.red | mix(color=palette.base, amount=0.1) | get(key="hex") }}"
+	minus-style = syntax "{{ palette.red | mix(color=palette.base, amount=0.1) | get(key="hex") }}"
 	# 25% green 75% base
-	plus-emph-style = "bold syntax {{ palette.green | mix(color=palette.base, amount=0.25) | get(key="hex") }}"
+	plus-emph-style = bold syntax "{{ palette.green | mix(color=palette.base, amount=0.25) | get(key="hex") }}"
 	# 10% green 90% base
-	plus-style = "syntax {{ palette.green | mix(color=palette.base, amount=0.1) | get(key="hex") }}"
+	plus-style = syntax "{{ palette.green | mix(color=palette.base, amount=0.1) | get(key="hex") }}"
 	map-styles = \
 		bold purple => syntax "{{ palette.mauve | mix(color=palette.base, amount=0.25) | get(key="hex") }}", \
 		bold blue => syntax "{{ palette.blue | mix(color=palette.base, amount=0.25) | get(key="hex") }}", \
 		bold cyan => syntax "{{ palette.sky | mix(color=palette.base, amount=0.25) | get(key="hex") }}", \
 		bold yellow => syntax "{{ palette.yellow | mix(color=palette.base, amount=0.25) | get(key="hex") }}"
 	# Should match the name of the bat theme
-	syntax-theme = "Catppuccin {{ identifier | capitalize }}"
+	syntax-theme = Catppuccin {{ identifier | capitalize }}
 {% if not loop.last %}
 {% endif -%}
 {% endfor -%}


### PR DESCRIPTION
https://github.com/dandavison/delta/blob/f5b37173fe88a62e37208a9587a0ab4fec0ef107/manual/src/configuration.md?plain=1#L36:

> Note that delta style argument values in ~/.gitconfig should be in double quotes, like `--minus-style="syntax #340001"`. For theme names and other values, do not use quotes as they will be passed on to delta, like `theme = Monokai Extended`.

https://github.com/dandavison/delta/blob/f5b37173fe88a62e37208a9587a0ab4fec0ef107/themes.gitconfig follows this, e.g. `syntax-theme = Vibrant Sunburst` and `syntax-theme = Monokai Extended`.