### PR TITLE
refactor: add whiskers check, remove justfile and add explicit `^`

### DIFF
--- a/.github/workflows/whiskers-check.yml
+++ b/.github/workflows/whiskers-check.yml
@@ -1,0 +1,16 @@
+name: whiskers
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: catppuccin/setup-whiskers@v2
+      - run: whiskers delta.tera --check catppuccin.gitconfig

--- a/delta.tera
+++ b/delta.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-  version: 2.5.1
+  version: ^2.5.1
   filename: "catppuccin.gitconfig"
   hex_format: "#{{r}}{{g}}{{b}}"
 ---

--- a/justfile
+++ b/justfile
@@ -1,5 +1,0 @@
-_default:
-  @just --list
-
-build:
-  whiskers delta.tera


### PR DESCRIPTION
In the future, this will be simplified even more once `whiskers` has the
ability to automatically detect the output file.

We've also moved away from shipping justfiles and ensuring that the versioning is explicit with the `^`.