### PR TITLE
Remove note about bat theme prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@
 
 ## Usage
 
-> [!IMPORTANT]
-> The [catppuccin/bat](https://github.com/catppuccin/bat) theme is a prerequisite for this port. Make sure to install it first!
-
 Include the themes in your gitconfig file and set your desired flavor as delta's theme like so:
 
 ```gitconfig


### PR DESCRIPTION
delta 0.19.0 includes https://github.com/dandavison/delta/pull/2115, which updates the bat dependency. The new version of bat includes the Catppuccin themes, so it is no longer a prerequisite.

delta 0.19.0 is in Homebrew already, but after looking at https://repology.org/project/git-delta/versions, you may want to wait a bit longer before merging this (or instead change the note to mention delta versions older than 0.19).